### PR TITLE
Enhancement: maximize free diskspace in github actions

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -71,7 +71,8 @@ jobs:
           sudo du -bsh /var/lib/docker
           sudo ls "${GITHUB_WORKSPACE}/docker/"
           sudo ls /var/lib/docker
-          sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+          sudo rm -rf /var/lib/docker
+          sudo mv ${GITHUB_WORKSPACE}/docker/ /var/lib/docker
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,9 +59,9 @@ jobs:
         uses: easimon/maximize-build-space@master
         with:
           root-reserve-mb: 512
+          temp-reserve-mb: 1024
           swap-size-mb: 1024
           remove-dotnet: 'true'
-          overprovision-lvm: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -56,7 +56,7 @@ jobs:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
       - name: Move /var/lib/docker/
-        run: sudo mv /var/lib/docker/* "${GITHUB_WORKSPACE}/docker"
+        run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -66,7 +66,7 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -61,6 +61,7 @@ jobs:
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          overprovision-lvm: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -55,6 +55,8 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      - name: Move /var/lib/docker/
+        run: sudo mv /var/lib/docker/* "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -63,6 +65,8 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
+      - name: Restore /var/lib/docker/
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -58,10 +58,14 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 512
-          temp-reserve-mb: 1024
-          swap-size-mb: 1024
+          build-mount-path: /var/lib/docker/
           remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          remove-docker-images: 'true'
+      - name: Restart docker
+        run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -55,6 +55,12 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -63,9 +63,6 @@ jobs:
           remove-android: 'true'
           remove-haskell: 'true'
           remove-codeql: 'true'
-          remove-docker-images: 'true'
-      - name: Restart docker
-        run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -67,10 +67,10 @@ jobs:
           remove-codeql: 'true'
       - name: Restore /var/lib/docker/
         run: |
-          du -bsh "${GITHUB_WORKSPACE}/docker/"
-          du -bsh /var/lib/docker
-          ls "${GITHUB_WORKSPACE}/docker/"
-          ls /var/lib/docker
+          sudo du -bsh "${GITHUB_WORKSPACE}/docker/"
+          sudo du -bsh /var/lib/docker
+          sudo ls "${GITHUB_WORKSPACE}/docker/"
+          sudo ls /var/lib/docker
           sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -55,6 +55,7 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      # save hadolint-action docker image, which for whatever reason builds before other steps
       - name: Move /var/lib/docker/
         run: sudo mv /var/lib/docker/ "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -66,7 +66,7 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -66,13 +66,7 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
       - name: Restore /var/lib/docker/
-        run: |
-          sudo du -bsh "${GITHUB_WORKSPACE}/docker/"
-          sudo du -bsh /var/lib/docker
-          sudo ls "${GITHUB_WORKSPACE}/docker/"
-          sudo ls /var/lib/docker
-          sudo rm -rf /var/lib/docker
-          sudo mv ${GITHUB_WORKSPACE}/docker/ /var/lib/docker
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -66,7 +66,12 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+        run: |
+          du -bsh "${GITHUB_WORKSPACE}/docker/"
+          du -bsh /var/lib/docker
+          ls "${GITHUB_WORKSPACE}/docker/"
+          ls /var/lib/docker
+          sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -59,6 +59,7 @@ jobs:
           root-reserve-mb: 512
           swap-size-mb: 1024
           remove-dotnet: 'true'
+          overprovision-lvm: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -53,6 +53,7 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      # save hadolint-action docker image, which for whatever reason builds before other steps
       - name: Move /var/lib/docker/
         run: sudo mv /var/lib/docker "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -57,9 +57,9 @@ jobs:
         uses: easimon/maximize-build-space@master
         with:
           root-reserve-mb: 512
+          temp-reserve-mb: 1024
           swap-size-mb: 1024
           remove-dotnet: 'true'
-          overprovision-lvm: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -64,8 +64,6 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
           build-mount-path: '/var/lib/docker/'
-      - name: Restart docker
-        run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -53,6 +53,8 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      - name: Move /var/lib/docker/
+        run: sudo mv /var/lib/docker/* "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -64,6 +66,8 @@ jobs:
           remove-haskell: 'true'
           remove-codeql: 'true'
           build-mount-path: '/var/lib/docker/'
+      - name: Restore /var/lib/docker/
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -57,9 +57,15 @@ jobs:
         uses: easimon/maximize-build-space@master
         with:
           root-reserve-mb: 512
-          temp-reserve-mb: 1024
-          swap-size-mb: 1024
+          temp-reserve-mb: 32
+          swap-size-mb: 32
           remove-dotnet: 'true'
+          remove-android: 'true'
+          remove-haskell: 'true'
+          remove-codeql: 'true'
+          build-mount-path: '/var/lib/docker/'
+      - name: Restart docker
+        run: sudo service docker restart
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -54,7 +54,7 @@ jobs:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
       - name: Move /var/lib/docker/
-        run: sudo mv /var/lib/docker/* "${GITHUB_WORKSPACE}/docker"
+        run: sudo mv /var/lib/docker "${GITHUB_WORKSPACE}/docker"
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
@@ -67,7 +67,7 @@ jobs:
           remove-codeql: 'true'
           build-mount-path: '/var/lib/docker/'
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -58,9 +58,6 @@ jobs:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master
         with:
-          root-reserve-mb: 512
-          temp-reserve-mb: 32
-          swap-size-mb: 32
           remove-dotnet: 'true'
           remove-android: 'true'
           remove-haskell: 'true'

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -67,7 +67,7 @@ jobs:
           remove-codeql: 'true'
           build-mount-path: '/var/lib/docker/'
       - name: Restore /var/lib/docker/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker /var/lib/docker"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib/docker"
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -53,6 +53,12 @@ jobs:
       matrix:
         tags: ["${{ fromJson(needs.dockerfile-changes.outputs.docker-images) }}"]
     steps:
+      - name: Maximize build space
+        uses: easimon/maximize-build-space@master
+        with:
+          root-reserve-mb: 512
+          swap-size-mb: 1024
+          remove-dotnet: 'true'
       - name: Checkout
         uses: actions/checkout@v4
       - name: Hadolint


### PR DESCRIPTION
Using easimon/maximize-build-space to clean up unused software for building containers.

This required a workaround to save the hadolint-action, hence why /var/lib/docker was stashed and then replaced. 