### PR TITLE
imageprivacy label

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -145,6 +145,17 @@ jobs:
           file: containers/${{ matrix.tags }}/Dockerfile
           tags: ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}}
           push: true
+      - name: Get privacy tag
+        id: check_private
+        run: |
+          if [ $(docker image inspect | grep -i "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+            { "private_image=true" } >> $GITHUB_OUTPUT
+          else
+            { "private_image=false" } >> $GITHUB_OUTPUT
+          fi
+      - name: Notify IMAGEPRIVACY
+        id: privacy_message
+        run: echo "This image is private"
   confirm-pass:
     runs-on: ubuntu-latest
     needs: [ dockerfile-changes, docker-validate-build, dockerfile-lint ]

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -148,12 +148,12 @@ jobs:
       - name: Get privacy tag
         id: check_private
         run: |
-          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"imageprivacy\": \"true\"") -gt 0 ] ; then
             echo "private_image=true" >> $GITHUB_OUTPUT
           else
             echo "private_image=false" >> $GITHUB_OUTPUT
           fi
-      - name: Notify IMAGEPRIVACY
+      - name: Notify imageprivacy
         id: privacy_message
         if: steps.check_private.outputs.private_image == 'true'
         run: echo "This image is private"

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -155,6 +155,7 @@ jobs:
           fi
       - name: Notify IMAGEPRIVACY
         id: privacy_message
+        if: steps.check_private.outputs.private_image == 'true'
         run: echo "This image is private"
   confirm-pass:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -148,10 +148,10 @@ jobs:
       - name: Get privacy tag
         id: check_private
         run: |
-          if [ $(docker image inspect | grep -i "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
-            { "private_image=true" } >> $GITHUB_OUTPUT
+          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+            echo "private_image=true" >> $GITHUB_OUTPUT
           else
-            { "private_image=false" } >> $GITHUB_OUTPUT
+            echo "private_image=false" >> $GITHUB_OUTPUT
           fi
       - name: Notify IMAGEPRIVACY
         id: privacy_message

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -141,9 +141,19 @@ jobs:
           file: containers/${{ matrix.tags }}/Dockerfile
           tags: ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}}
           push: true
+      - name: Get privacy tag
+        id: check_private
+        run: |
+          if [ $(docker image inspect | grep -i "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+            { "private_image=true" } >> $GITHUB_OUTPUT
+          else
+            { "private_image=false" } >> $GITHUB_OUTPUT
+          fi
       - name: Log in to GHCR registry
+        if: steps.check_private.outputs.private_image == 'true'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build and push image to GHCR registry
+        if: steps.check_private.outputs.private_image == 'true'
         uses: docker/build-push-action@v5
         with:
           context: containers/${{ matrix.tags }}/

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -150,10 +150,10 @@ jobs:
             echo "private_image=false" >> $GITHUB_OUTPUT
           fi
       - name: Log in to GHCR registry
-        if: steps.check_private.outputs.private_image == 'true'
+        if: steps.check_private.outputs.private_image == 'false'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       - name: Build and push image to GHCR registry
-        if: steps.check_private.outputs.private_image == 'true'
+        if: steps.check_private.outputs.private_image == 'false'
         uses: docker/build-push-action@v5
         with:
           context: containers/${{ matrix.tags }}/

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -144,10 +144,10 @@ jobs:
       - name: Get privacy tag
         id: check_private
         run: |
-          if [ $(docker image inspect | grep -i "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
-            { "private_image=true" } >> $GITHUB_OUTPUT
+          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+            echo "private_image=true" >> $GITHUB_OUTPUT
           else
-            { "private_image=false" } >> $GITHUB_OUTPUT
+            echo "private_image=false" >> $GITHUB_OUTPUT
           fi
       - name: Log in to GHCR registry
         if: steps.check_private.outputs.private_image == 'true'

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Get privacy tag
         id: check_private
         run: |
-          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"IMAGEPRIVACY\": \"true\"") -gt 0 ] ; then
+          if [ $(docker image inspect ${{ env.JFROG_CONTAINER_REPO }}/${{ steps.docker_repo_name.outputs.name}}:${{steps.docker_repo_version.outputs.version}} | grep -ic "\"imageprivacy\": \"true\"") -gt 0 ] ; then
             echo "private_image=true" >> $GITHUB_OUTPUT
           else
             echo "private_image=false" >> $GITHUB_OUTPUT

--- a/.hadolint.yml
+++ b/.hadolint.yml
@@ -1,3 +1,26 @@
 ignored:
   - DL3008
   - DL3013
+
+failure-threshold: warning
+
+no-fail: false
+
+label-schema:
+  imageprivacy: text
+  org.opencontainers.image.vendor: text
+  org.opencontainers.image.authors: text
+  org.opencontainers.image.created: rfc3339
+  org.opencontainers.image.version: text
+  org.opencontainers.image.licenses: text
+  org.opencontainers.image.source: text
+  org.opencontainers.image.url: text
+  org.opencontainers.image.title: text
+  org.opencontainers.image.description: text
+
+override:
+  error:
+    - DL3048
+    - DL3050
+
+strict-labels: true

--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ LABEL \
 ```
 It is also acceptable to use no extension.
 
-The `imageprivacy` label is optional. When set to `"true"`, the image will not be pushed to the ghcr container registry. For all other values, the image will be pushed to the container registry when merged to main. See `containers/testappprivate` for an example.
-
 Superfluous labels will cause the Dockerfile linting to fail. Missing labels will produce an Info message, but will not trigger a failure. Test your local Dockerfile using `hadolint containers/<image>/<version>/Dockerfile` from the top-level folder of the git repo.
+
+### Private Images
+
+By default, image recipes are built and pushed to JFrog, which is private to MSKCC, and GHCR, which is public. If the optional `imageprivacy` label is used in the Dockerfile, this behavior can be modified. When set to `"true"`, the image will not be pushed to the GHCR container registry. For all other values, the image will be pushed to the container registry when merged to main. See `containers/testappprivate` for an example.
 
 #### Created Date
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ It is also acceptable to use no extension.
 
 Superfluous labels will cause the Dockerfile linting to fail. Missing labels will produce an Info message, but will not trigger a failure. Test your local Dockerfile using `hadolint containers/<image>/<version>/Dockerfile` from the top-level folder of the git repo.
 
-### Private Images
+#### Private Images
 
 By default, image recipes are built and pushed to JFrog, which is private to MSKCC, and GHCR, which is public. If the optional `imageprivacy` label is used in the Dockerfile, this behavior can be modified. When set to `"true"`, the image will not be pushed to the GHCR container registry. For all other values, the image will be pushed to the container registry when merged to main. See `containers/testappprivate` for an example.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ LABEL \
 ```
 It is also acceptable to use no extension.
 
+The `imageprivacy` label is optional. When set to `"true"`, the image will not be pushed to the ghcr container registry. For all other values, the image will be pushed to the container registry when merged to main. See `containers/testappprivate` for an example.
+
+Superfluous labels will cause the Dockerfile linting to fail. Missing labels will produce an Info message, but will not trigger a failure. Test your local Dockerfile using `hadolint containers/<image>/<version>/Dockerfile` from the top-level folder of the git repo.
+
 #### Created Date
 
 The `org.opencontainers.image.created` label should be used to timestamp the image as accurately as possible. The value should match the following regular expression:

--- a/containers/testappprivate/0.0.1/Dockerfile
+++ b/containers/testappprivate/0.0.1/Dockerfile
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/
 LABEL org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/"
 LABEL org.opencontainers.image.title="My private test app"
 LABEL org.opencontainers.image.description="My private test app description"
-LABEL IMAGEPRIVACY="true"
+LABEL imageprivacy="true"
 
 
 

--- a/containers/testappprivate/0.0.1/Dockerfile
+++ b/containers/testappprivate/0.0.1/Dockerfile
@@ -4,8 +4,9 @@ FROM python:3.9-slim
 LABEL org.opencontainers.image.vendor="MSKCC-OMICS-WORKFLOWS"
 LABEL org.opencontainers.image.authors="Anne Marie Noronha (noronhaa@mskcc.org)"
 
-LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z" \
-    org.opencontainers.image.version="0.0.1" \
+LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z"
+
+LABEL org.opencontainers.image.version="0.0.1" \
     org.opencontainers.image.licenses="test-license" \
     org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testappprivate/" \
     org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/" \

--- a/containers/testappprivate/0.0.1/Dockerfile
+++ b/containers/testappprivate/0.0.1/Dockerfile
@@ -3,16 +3,14 @@ FROM python:3.9-slim
 # Labels
 LABEL org.opencontainers.image.vendor="MSKCC-OMICS-WORKFLOWS"
 LABEL org.opencontainers.image.authors="Anne Marie Noronha (noronhaa@mskcc.org)"
-
 LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z"
-
-LABEL org.opencontainers.image.version="0.0.1" \
-    org.opencontainers.image.licenses="test-license" \
-    org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testappprivate/" \
-    org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/" \
-    org.opencontainers.image.title="My private test app" \
-    org.opencontainers.image.description="My private test app description" \
-    IMAGEPRIVACY="true"
+LABEL org.opencontainers.image.version="0.0.1"
+LABEL org.opencontainers.image.licenses="test-license"
+LABEL org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testappprivate/"
+LABEL org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/"
+LABEL org.opencontainers.image.title="My private test app"
+LABEL org.opencontainers.image.description="My private test app description"
+LABEL IMAGEPRIVACY="true"
 
 
 

--- a/containers/testappprivate/0.0.1/Dockerfile
+++ b/containers/testappprivate/0.0.1/Dockerfile
@@ -1,0 +1,34 @@
+FROM python:3.9-slim
+
+# Labels
+LABEL org.opencontainers.image.vendor="MSKCC-OMICS-WORKFLOWS"
+LABEL org.opencontainers.image.authors="Anne Marie Noronha (noronhaa@mskcc.org)" 
+
+LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z" \ 
+	org.opencontainers.image.version="0.0.1" \
+	org.opencontainers.image.licenses="test-license" \
+	org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testapp/" \
+    org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/" \
+    org.opencontainers.image.title="My test app" \
+    org.opencontainers.image.description="My test app description" \
+    IMAGEPRIVACY="true"    
+
+
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the current directory contents into the container at /app
+COPY . /app
+
+# Install any needed dependencies specified in requirements.txt
+# For this example, we won't have any dependencies
+# RUN pip install --no-cache-dir -r requirements.txt
+
+# Define environment variable
+ENV NAME World
+
+# Run app.py when the container launches
+CMD ["python", "app.py"]
+
+

--- a/containers/testappprivate/0.0.1/Dockerfile
+++ b/containers/testappprivate/0.0.1/Dockerfile
@@ -2,16 +2,16 @@ FROM python:3.9-slim
 
 # Labels
 LABEL org.opencontainers.image.vendor="MSKCC-OMICS-WORKFLOWS"
-LABEL org.opencontainers.image.authors="Anne Marie Noronha (noronhaa@mskcc.org)" 
+LABEL org.opencontainers.image.authors="Anne Marie Noronha (noronhaa@mskcc.org)"
 
-LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z" \ 
-	org.opencontainers.image.version="0.0.1" \
-	org.opencontainers.image.licenses="test-license" \
-	org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testapp/" \
+LABEL org.opencontainers.image.created="2020-12-16T15:55:35Z" \
+    org.opencontainers.image.version="0.0.1" \
+    org.opencontainers.image.licenses="test-license" \
+    org.opencontainers.image.source="https://github.com/mskcc-omics-workflows/containers/containers/testappprivate/" \
     org.opencontainers.image.url="https://github.com/mskcc-omics-workflows/containers/" \
-    org.opencontainers.image.title="My test app" \
-    org.opencontainers.image.description="My test app description" \
-    IMAGEPRIVACY="true"    
+    org.opencontainers.image.title="My private test app" \
+    org.opencontainers.image.description="My private test app description" \
+    IMAGEPRIVACY="true"
 
 
 

--- a/containers/testappprivate/0.0.1/app.py
+++ b/containers/testappprivate/0.0.1/app.py
@@ -1,0 +1,3 @@
+import os
+
+print("Hello, " + os.environ['NAME'] + "!")


### PR DESCRIPTION
added handling of a label called "imageprivacy" that controls where the image is uploaded. if private, it uploads to jfrog only. If public, it uploads to jfrog and ghcr.

Updated the hadolint config to accommodate this label. Now all superfluous labels not included in the label-schema block of .hadolint.yml will trigger a failure.