### PR TITLE
fix(hlahd): cd into HLAHD_DIR, install unzip, validate build outputs

### DIFF
--- a/containers/hlahd/1.7.1/Dockerfile
+++ b/containers/hlahd/1.7.1/Dockerfile
@@ -26,6 +26,7 @@ RUN  --mount=type=secret,id=MSK_JFROG_USERNAME \
       g++ \
       perl \
       python3 \
+      unzip \
       wget \
       bowtie2 \
       && \
@@ -37,8 +38,23 @@ RUN  --mount=type=secret,id=MSK_JFROG_USERNAME \
       tar -zxvf /tmp/hlahdTmp/hlahd.1.7.1.tar.gz -C /opt/hlahd/ && \
       HLAHD_DIR="$(find /opt/hlahd -maxdepth 1 -type d -name 'hlahd.*' | head -1)" && \
       test -n "$HLAHD_DIR" && \
-      bash "$HLAHD_DIR/install.sh" && \
-      sh "$HLAHD_DIR/update.dictionary.sh" && \
+      # install.sh and update.dictionary.sh use relative paths (./src, ./bin,
+      # dictionary/) so we must run them from $HLAHD_DIR. Without cd, the
+      # scripts emit non-fatal errors and exit 0, leaving an unusable image.
+      cd "$HLAHD_DIR" && \
+      bash ./install.sh && \
+      sh ./update.dictionary.sh && \
+      cd / && \
+      # Validate that compilation and dictionary index build actually produced
+      # the artifacts we depend on. Without these checks, a silent script
+      # failure would publish a broken image.
+      test -x "$HLAHD_DIR/bin/pm_extract" && \
+      test -x "$HLAHD_DIR/bin/stfr" && \
+      test -x "$HLAHD_DIR/bin/get_diff_fasta" && \
+      test -x "$HLAHD_DIR/bin/split_pm_read" && \
+      test -x "$HLAHD_DIR/bin/split_shell" && \
+      test -f "$HLAHD_DIR/dictionary/all_exon_N150.fasta.1.bt2" && \
+      test -f "$HLAHD_DIR/dictionary/all_intron_N150.fasta.1.bt2" && \
       ln -s "$HLAHD_DIR" /opt/hlahd/current && \
       # Clean up
       apt-get clean && \

--- a/containers/hlahd/1.7.1/Dockerfile
+++ b/containers/hlahd/1.7.1/Dockerfile
@@ -16,6 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+# hadolint ignore=DL3003
 RUN  --mount=type=secret,id=MSK_JFROG_USERNAME \
       --mount=type=secret,id=MSK_JFROG_TOKEN \
       set -eux && apt-get update -y && \
@@ -44,7 +45,6 @@ RUN  --mount=type=secret,id=MSK_JFROG_USERNAME \
       cd "$HLAHD_DIR" && \
       bash ./install.sh && \
       sh ./update.dictionary.sh && \
-      cd / && \
       # Validate that compilation and dictionary index build actually produced
       # the artifacts we depend on. Without these checks, a silent script
       # failure would publish a broken image.


### PR DESCRIPTION
The published image at omicswf-docker-prod-local/.../hlahd:1.7.1 is unusable: /opt/hlahd/current/bin contains only hlahd.sh (no compiled helpers), dictionary/ has the source fastas but no bowtie2 indices, and freq_data/ is empty. CI confirmed this against the running image.

Root cause, observed in the 2026-03-23 prod-build log:

  + bash /opt/hlahd/hlahd.1.7.1/install.sh cc1plus: fatal error: ./src/pm_extract.cpp: No such file or directory install.sh: line 12: cd: dictionary/: No such file or directory
  + sh /opt/hlahd/hlahd.1.7.1/update.dictionary.sh update.dictionary.sh: 7: unzip: not found update.dictionary.sh: 19: ./bin/create_fasta_from_dat: not found

Problems:

1. install.sh and update.dictionary.sh use relative paths (./src, ./bin, dictionary/), so they must run from $HLAHD_DIR. The previous Dockerfile invoked them by absolute path with no cd, so every relative reference failed.

2. update.dictionary.sh requires `unzip`, which was not in the apt install list.

3. Both scripts swallow errors and exit 0, so `bash install.sh` and `sh update.dictionary.sh` returned success and the chained && did not break. The broken layer was committed and pushed.

Changes:
- Add `unzip` to the apt install list.
- `cd "$HLAHD_DIR"` before running install.sh / update.dictionary.sh.
- Add explicit `test -x` / `test -f` checks for the compiled helpers and the bowtie2 indices so a future silent script failure aborts the build instead of publishing another broken image.